### PR TITLE
Checking for correctness

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
           packages = with pkgsFor.${system}; [
             gcc14                   # compiler
             cmake                   # build system
+          ];
           shellHook = ''
               zsh
           '';


### PR DESCRIPTION
## Description
This PR implements a checking function to check for the correctness of the regular expression. The function returns a `regez_error` enum with the result of the evaluation. The technique used is not sophisticated and lacks many checks, this can be greately improved in future work.

Testcases have been added to test the function.

## Related Issues
#7 